### PR TITLE
Add support for Ruby 2.4

### DIFF
--- a/lib/latest_ruby.rb
+++ b/lib/latest_ruby.rb
@@ -21,12 +21,16 @@ module Latest
     File.read(VERSION_FILE).chomp : '(could not find VERSION file)'
 
   class << self
-    def ruby23
-      Ruby.new(MRI.new('2.3', MRIRetriever.new))
+    def ruby24
+      Ruby.new(MRI.new('2.4', MRIRetriever.new))
     end
 
     # The latest Ruby version by default.
-    alias_method :ruby, :ruby23
+    alias_method :ruby, :ruby24
+
+    def ruby23
+      Ruby.new(MRI.new('2.3', MRIRetriever.new))
+    end
 
     def ruby22
       Ruby.new(MRI.new('2.2', MRIRetriever.new))


### PR DESCRIPTION
Ruby 2.4.0 released.

cf. http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/78822