### PR TITLE
fix: Does not work with ver3.0.0

### DIFF
--- a/latest_ruby.gemspec
+++ b/latest_ruby.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.files        = `git ls-files`.split("\n")
 
+  s.add_dependency 'rexml'
+
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry'
 end


### PR DESCRIPTION
It didn't work in Ruby v3.0.0 because `rexml` was changed to bundled gems as shown below.

- Feature #16485: Make rexml, rss to the bundled gems - Ruby master - Ruby Issue Tracking System
https://bugs.ruby-lang.org/issues/16485

I'm sorry I didn't notice it during the last PR.