### PR TITLE
Update rbx sources

### DIFF
--- a/latest_ruby.gemspec
+++ b/latest_ruby.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.files        = `git ls-files`.split("\n")
 
-  s.add_dependency 'rexml'
-
   s.add_development_dependency 'rake'
   s.add_development_dependency 'pry'
 end

--- a/lib/latest_ruby/retrievers/rubinius_retriever.rb
+++ b/lib/latest_ruby/retrievers/rubinius_retriever.rb
@@ -1,18 +1,11 @@
-require 'rexml/document'
+require 'json'
 
 module Latest
   class RubiniusRetriever
-
-    include REXML
-
     def retrieve(rbx)
       page = Net::HTTP.get(URI(rbx.source))
-      xml  = Document.new(page)
-      all_versions = XPath.match(xml, '//Contents//Key').map(&:text)
-      candidates = all_versions.find_all { |v| v =~ /\Arubinius-/ }
-      stables = candidates.flat_map { |v| v.scan(/-(\d\.\d\.\d)\.tar/) }.flatten
-      stables.map { |v| RubyVersion.new(v) }.max
+      latest_version = JSON.parse(page)
+      RubyVersion.new(latest_version['tag_name'].scan(/\d.\d/).first)
     end
-
   end
 end

--- a/lib/latest_ruby/rubies/rubinius.rb
+++ b/lib/latest_ruby/rubies/rubinius.rb
@@ -1,23 +1,23 @@
 module Latest
   class Rubinius
-
-    SOURCE = 'http://asset.rubini.us/'
-    AVAILABLE_EXTS = ['.tar.gz']
+    WEB_SOURCE = 'https://api.github.com/repos/rubinius/rubinius/releases/latest'
+    SOURCE = 'https://github.com/rubinius/rubinius/releases/download'
+    AVAILABLE_EXTS = ['.tar.bz2']
 
     attr_reader :source
 
     def initialize(retriever)
       @retriever = retriever
-      @source = SOURCE
+      @source = WEB_SOURCE
     end
 
     def version
       @version ||= @retriever.retrieve(self)
     end
 
-    def link(ext = '.tar.gz')
+    def link(ext = '.tar.bz2')
       if AVAILABLE_EXTS.include?(ext)
-        source + 'rubinius-' + version.to_s + ext
+        "#{SOURCE}/v#{version}/rubinius-#{version}#{ext}"
       end
     end
 


### PR DESCRIPTION
Seems like rbx sources on rubi.us are not updated in a while, so I updated this to point to github releases. Which seems a more updated source.

Another mirror could be [this](http://rubinius-releases-rubinius-com.s3-us-west-2.amazonaws.com) which is used by ruby-build too. 

By doing this, it's possible to remove the rexml dependency too. And https://github.com/pry/pry-doc/pull/118 would no longer be necessary 

```
irb(main):003:0> Latest.rbx.link
=> "https://github.com/rubinius/rubinius/releases/download/v5.0/rubinius-5.0.tar.bz2"
```