### PR TITLE
support Ruby 3.2

### DIFF
--- a/lib/latest_ruby.rb
+++ b/lib/latest_ruby.rb
@@ -21,6 +21,10 @@ module Latest
     File.read(VERSION_FILE).chomp : '(could not find VERSION file)'
 
   class << self
+    def ruby32
+      Ruby.new(MRI.new('3.2', MRIRetriever.new))
+    end
+
     def ruby31
       Ruby.new(MRI.new('3.1', MRIRetriever.new))
     end
@@ -42,7 +46,7 @@ module Latest
     end
 
     # The latest Ruby version by default.
-    alias_method :ruby, :ruby31
+    alias_method :ruby, :ruby32
 
     def ruby24
       Ruby.new(MRI.new('2.4', MRIRetriever.new))


### PR DESCRIPTION
Ruby 3.2 was released a few days ago. https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

Closes issue https://github.com/kyrylo/latest_ruby/issues/23